### PR TITLE
Fix bug on getting dominant resource

### DIFF
--- a/src/test/java/com/netflix/control/clutch/ClutchConfiguratorTest.java
+++ b/src/test/java/com/netflix/control/clutch/ClutchConfiguratorTest.java
@@ -16,6 +16,7 @@
 
 package com.netflix.control.clutch;
 
+import com.netflix.control.clutch.metrics.IClutchMetricsRegistry;
 import com.yahoo.sketches.quantiles.UpdateDoublesSketch;
 import org.assertj.core.data.Offset;
 import org.junit.Test;
@@ -47,6 +48,12 @@ public class ClutchConfiguratorTest {
         }
 
         assertThat(sketch.getQuantile(0.99)).isLessThan(76.0);
+    }
+
+    @Test public void shouldGetConfig() {
+        ClutchConfigurator configurator = new ClutchConfigurator(new IClutchMetricsRegistry() {}, 1, 2, Observable.interval(1, TimeUnit.DAYS));
+        configurator.getSketch(Clutch.Metric.CPU).update(70.0);
+        configurator.getConfig();
     }
 
     // TODO: What guarantees do I want to make about the configurator?

--- a/src/test/java/com/netflix/control/clutch/ClutchConfiguratorTest.java
+++ b/src/test/java/com/netflix/control/clutch/ClutchConfiguratorTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 public class ClutchConfiguratorTest {
 
@@ -50,10 +51,10 @@ public class ClutchConfiguratorTest {
         assertThat(sketch.getQuantile(0.99)).isLessThan(76.0);
     }
 
-    @Test public void shouldGetConfig() {
+    @Test public void shouldGetConfigWithoutException() {
         ClutchConfigurator configurator = new ClutchConfigurator(new IClutchMetricsRegistry() {}, 1, 2, Observable.interval(1, TimeUnit.DAYS));
         configurator.getSketch(Clutch.Metric.CPU).update(70.0);
-        configurator.getConfig();
+        assertNotNull(configurator.getConfig());
     }
 
     // TODO: What guarantees do I want to make about the configurator?


### PR DESCRIPTION
### Context

Get daily config will always fail due to this Java stream double consumption bug. This means clutch configurator will only emit the pin-high config.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
