### PR TITLE
Introduce integral decay factor in PIDController

### DIFF
--- a/src/main/java/com/netflix/control/clutch/ClutchConfiguration.java
+++ b/src/main/java/com/netflix/control/clutch/ClutchConfiguration.java
@@ -39,6 +39,9 @@ public @Builder(access = AccessLevel.PUBLIC) @Value class ClutchConfiguration {
     public final double ki;
     /** Derivative controller gain. */
     public final double kd;
+    /** Integral component decay factor. */
+    @Builder.Default
+    public final double integralDecay = 1.0;
 
     /** Minimum size for autoscaling. */
     public final int minSize;

--- a/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
+++ b/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
@@ -99,7 +99,7 @@ public class ExperimentalControlLoop implements Observable.Transformer<Event, Do
                             + (triple._3.value); // Drops are average, and thus per-worker.
                 })
                 .lift(new ErrorComputer(config.setPoint, true, config.rope._1, config.rope._2))
-                .lift(new PIDController(config.kp, config.ki, config.kd))
+                .lift(new PIDController(config.kp, config.ki, config.kd, 1.0, new AtomicDouble(1.0), config.integralDecay))
                 .lift(integrator)
                 .filter(__ -> this.cooldownMillis == 0 || cooldownTimestamp.get() <= System.currentTimeMillis() - this.cooldownMillis)
                 .filter(scale -> this.currentScale.get() != Math.round(Math.ceil(scale)))

--- a/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
+++ b/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
@@ -99,7 +99,7 @@ public class ExperimentalControlLoop implements Observable.Transformer<Event, Do
                             + (triple._3.value); // Drops are average, and thus per-worker.
                 })
                 .lift(new ErrorComputer(config.setPoint, true, config.rope._1, config.rope._2))
-                .lift(PIDController.of(config.kp, config.ki, config.kd))
+                .lift(new PIDController(config.kp, config.ki, config.kd))
                 .lift(integrator)
                 .filter(__ -> this.cooldownMillis == 0 || cooldownTimestamp.get() <= System.currentTimeMillis() - this.cooldownMillis)
                 .filter(scale -> this.currentScale.get() != Math.round(Math.ceil(scale)))

--- a/src/main/java/com/netflix/control/controllers/ControlLoop.java
+++ b/src/main/java/com/netflix/control/controllers/ControlLoop.java
@@ -69,7 +69,7 @@ public class ControlLoop implements Observable.Transformer<Event, Double>  {
                 .map(e -> e.value)
                 .doOnNext(sketch::update)
                 .lift(new ErrorComputer(config.setPoint, true, config.rope._1, config.rope._2))
-                .lift(new PIDController(config.kp, config.ki, config.kd))
+                .lift(new PIDController(config.kp, config.ki, config.kd, 1.0, new AtomicDouble(1.0), config.integralDecay))
                 .lift(new Integrator(currentScale.get(), config.minSize, config.maxSize))
                 .filter(__ -> this.cooldownMillis == 0 || cooldownTimestamp.get() <= System.currentTimeMillis() - this.cooldownMillis)
                 .filter(scale -> this.currentScale.get() != Math.round(Math.ceil(scale)))

--- a/src/main/java/com/netflix/control/controllers/ControlLoop.java
+++ b/src/main/java/com/netflix/control/controllers/ControlLoop.java
@@ -69,7 +69,7 @@ public class ControlLoop implements Observable.Transformer<Event, Double>  {
                 .map(e -> e.value)
                 .doOnNext(sketch::update)
                 .lift(new ErrorComputer(config.setPoint, true, config.rope._1, config.rope._2))
-                .lift(PIDController.of(config.kp, config.ki, config.kd))
+                .lift(new PIDController(config.kp, config.ki, config.kd))
                 .lift(new Integrator(currentScale.get(), config.minSize, config.maxSize))
                 .filter(__ -> this.cooldownMillis == 0 || cooldownTimestamp.get() <= System.currentTimeMillis() - this.cooldownMillis)
                 .filter(scale -> this.currentScale.get() != Math.round(Math.ceil(scale)))

--- a/src/main/java/com/netflix/control/controllers/PIDController.java
+++ b/src/main/java/com/netflix/control/controllers/PIDController.java
@@ -30,8 +30,6 @@ import com.netflix.control.IController;
  */
 public class PIDController extends IController {
 
-  public static final double DEFAULT_INTEGRAL_DECAY = 0.9;
-
   private final Double kp; // Proportional Gain
   private final Double ki; // Integral Gain
   private final Double kd; // Derivative Gain
@@ -76,7 +74,7 @@ public class PIDController extends IController {
   }
 
   public PIDController(Double kp, Double ki, Double kd) {
-    this(kp, ki, kd, 1.0, new AtomicDouble(1.0), DEFAULT_INTEGRAL_DECAY);
+    this(kp, ki, kd, 1.0, new AtomicDouble(1.0), 1.0);
   }
 
   @Override
@@ -99,7 +97,7 @@ public class PIDController extends IController {
    */
   @Deprecated
   public static PIDController of(Double kp, Double ki, Double kd, AtomicDouble dampener) {
-    return new PIDController(kp, ki, kd, 1.0, dampener, DEFAULT_INTEGRAL_DECAY);
+    return new PIDController(kp, ki, kd, 1.0, dampener, 1.0);
   }
 
   /**
@@ -108,7 +106,7 @@ public class PIDController extends IController {
    */
   @Deprecated
   public static PIDController of(Double kp, Double ki, Double kd, Double deltaT) {
-    return new PIDController(kp, ki, kd, deltaT, new AtomicDouble(1.0), DEFAULT_INTEGRAL_DECAY);
+    return new PIDController(kp, ki, kd, deltaT, new AtomicDouble(1.0), 1.0);
   }
 
   /**
@@ -117,7 +115,7 @@ public class PIDController extends IController {
    */
   @Deprecated
   public static PIDController of(Double kp, Double ki, Double kd) {
-    return new PIDController(kp, ki, kd, 1.0, new AtomicDouble(1.0), DEFAULT_INTEGRAL_DECAY);
+    return new PIDController(kp, ki, kd, 1.0, new AtomicDouble(1.0), 1.0);
   }
 
   public AtomicDouble getDampener() {

--- a/src/main/java/com/netflix/control/controllers/PIDController.java
+++ b/src/main/java/com/netflix/control/controllers/PIDController.java
@@ -30,6 +30,8 @@ import com.netflix.control.IController;
  */
 public class PIDController extends IController {
 
+  public static final double DEFAULT_INTEGRAL_DECAY = 0.9;
+
   private final Double kp; // Proportional Gain
   private final Double ki; // Integral Gain
   private final Double kd; // Derivative Gain
@@ -37,6 +39,7 @@ public class PIDController extends IController {
 
   private final double deltaT;
   private final AtomicDouble dampener;
+  private final double integralDecay;
 
   private Double integral = 0.0;
   private Double derivative = 0.0;
@@ -50,6 +53,7 @@ public class PIDController extends IController {
    * @param kd The gain for the derivative component of the controller.
    * @param deltaT The time delta. A useful default is 1.0.
    * @param dampener A dampening signal which can be used for gain scheduling.
+   * @param integralDecay Factor [0.0, 1.0] to decay the integral component on each step.
    *
    * Setting the gain for an individual component disables said
    * component. For example setting kd to 0.0 creates a PI (two term) control
@@ -62,44 +66,65 @@ public class PIDController extends IController {
    * Oscillation: High gain can exacerbate and even cause oscillation.
    * Chaos Kong: Increasing gain to accelerate scale ups.
    */
-  public PIDController(Double kp, Double ki, Double kd, Double deltaT, AtomicDouble dampener) {
+  public PIDController(Double kp, Double ki, Double kd, Double deltaT, AtomicDouble dampener, double integralDecay) {
     this.kp = kp;
     this.ki = ki;
     this.kd = kd;
     this.deltaT = deltaT;
     this.dampener = dampener;
+    this.integralDecay = integralDecay;
   }
 
-  public PIDController(Double kp, Double ki, Double kd, Double deltaT) {
-    this(kp, ki, kd, deltaT, new AtomicDouble(1.0));
+  public PIDController(Double kp, Double ki, Double kd) {
+    this(kp, ki, kd, 1.0, new AtomicDouble(1.0), DEFAULT_INTEGRAL_DECAY);
   }
 
   @Override
   public Double processStep(Double error) {
-        this.integral += this.deltaT * error;
+    double curIntegral = this.integral + this.deltaT * error;
         this.derivative =  (error - this.previous) / this.deltaT;
         this.previous = error;
+        this.integral = this.integralDecay * curIntegral;
 
         double d = this.dampener.get();
 
         return this.kp * d * error
-                + this.ki * d * this.integral
+                + this.ki * d * curIntegral
                 + this.kd * d * this.derivative;
   }
 
+  /**
+   * @deprecated
+   * Use the public constructors
+   */
+  @Deprecated
   public static PIDController of(Double kp, Double ki, Double kd, AtomicDouble dampener) {
-    return new PIDController(kp, ki, kd, 1.0, dampener);
+    return new PIDController(kp, ki, kd, 1.0, dampener, DEFAULT_INTEGRAL_DECAY);
   }
 
+  /**
+   * @deprecated
+   * Use the public constructors
+   */
+  @Deprecated
   public static PIDController of(Double kp, Double ki, Double kd, Double deltaT) {
-    return new PIDController(kp, ki, kd, deltaT);
+    return new PIDController(kp, ki, kd, deltaT, new AtomicDouble(1.0), DEFAULT_INTEGRAL_DECAY);
   }
 
+  /**
+   * @deprecated
+   * Use the public constructors
+   */
+  @Deprecated
   public static PIDController of(Double kp, Double ki, Double kd) {
-    return new PIDController(kp, ki, kd, 1.0, new AtomicDouble(1.0));
+    return new PIDController(kp, ki, kd, 1.0, new AtomicDouble(1.0), DEFAULT_INTEGRAL_DECAY);
   }
 
   public AtomicDouble getDampener() {
     return this.dampener;
+  }
+
+  public double getIntegralDecay() {
+    return this.integralDecay;
   }
 }

--- a/src/main/java/com/netflix/control/examples/ExampleAutoScaler.java
+++ b/src/main/java/com/netflix/control/examples/ExampleAutoScaler.java
@@ -17,6 +17,7 @@
 package com.netflix.control.examples;
 
 
+import com.google.common.util.concurrent.AtomicDouble;
 import com.netflix.control.actuators.MantisJobActuator;
 import com.netflix.control.controllers.PIDController;
 import com.netflix.control.controllers.ErrorComputer;

--- a/src/main/java/com/netflix/control/examples/ExampleAutoScaler.java
+++ b/src/main/java/com/netflix/control/examples/ExampleAutoScaler.java
@@ -67,7 +67,7 @@ public class ExampleAutoScaler implements Observable.Transformer<Double, Double>
                     kd: Derivative gain, multiplied by the diference between error now
                         and at t-1.
                  */
-                .lift(PIDController.of(kp, ki, kd))
+                .lift(new PIDController(kp, ki, kd))
                 /*
                     The integrator's job is to sum up the output of the controller. The
                     reason we integrate is because our actuator expects whole size numbers. If

--- a/src/test/java/com/netflix/control/clutch/ClutchConfigurationTest.java
+++ b/src/test/java/com/netflix/control/clutch/ClutchConfigurationTest.java
@@ -1,0 +1,18 @@
+package com.netflix.control.clutch;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClutchConfigurationTest {
+    @Test
+    public void shouldCreateClutchConfiguration() {
+        ClutchConfiguration config = ClutchConfiguration.builder().kd(1.0).build();
+        assertEquals(1.0, config.kd, 1e-10);
+        assertEquals(1.0, config.integralDecay, 1e-10);
+
+        config = ClutchConfiguration.builder().kd(1.0).integralDecay(0.9).build();
+        assertEquals(1.0, config.kd, 1e-10);
+        assertEquals(0.9, config.integralDecay, 1e-10);
+    }
+}

--- a/src/test/java/com/netflix/control/controllers/PIDControllerTest.java
+++ b/src/test/java/com/netflix/control/controllers/PIDControllerTest.java
@@ -1,0 +1,22 @@
+package com.netflix.control.controllers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PIDControllerTest {
+    @Test
+    public void shouldComputeSignal() {
+        PIDController controller = new PIDController(1.0, 1.0, 1.0);
+        double signal = controller.processStep(10.0);
+        assertEquals(30, signal, 1e-10);
+
+        signal = controller.processStep(10.0);
+        // p: 10, i: 19, d: 0
+        assertEquals(29, signal, 1e-10);
+
+        signal = controller.processStep(20.0);
+        // p: 20, i: 27.1, d: 10
+        assertEquals(67.1, signal, 1e-10);
+    }
+}

--- a/src/test/java/com/netflix/control/controllers/PIDControllerTest.java
+++ b/src/test/java/com/netflix/control/controllers/PIDControllerTest.java
@@ -1,5 +1,6 @@
 package com.netflix.control.controllers;
 
+import com.google.common.util.concurrent.AtomicDouble;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -7,7 +8,7 @@ import static org.junit.Assert.assertEquals;
 public class PIDControllerTest {
     @Test
     public void shouldComputeSignal() {
-        PIDController controller = new PIDController(1.0, 1.0, 1.0);
+        PIDController controller = new PIDController(1.0, 1.0, 1.0, 1.0, new AtomicDouble(1.0), 0.9);
         double signal = controller.processStep(10.0);
         assertEquals(30, signal, 1e-10);
 


### PR DESCRIPTION
### Context

We need to decay the integral component of the PID controller. Without it, one single outlier input can skew the PID controller forever.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
