### PR TITLE
Support decay in Integrator

### DIFF
--- a/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
+++ b/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
@@ -79,7 +79,7 @@ public class ExperimentalControlLoop implements Observable.Transformer<Event, Do
 
         Observable<Event> rps = events.filter(event -> event.getMetric() == Clutch.Metric.RPS);
 
-        Integrator integrator = new Integrator(initialSize, config.minSize, config.maxSize);
+        Integrator integrator = new Integrator(initialSize, config.minSize, config.maxSize, config.integralDecay);
 
         size
                 .takeUntil(timer)

--- a/src/main/java/com/netflix/control/controllers/ControlLoop.java
+++ b/src/main/java/com/netflix/control/controllers/ControlLoop.java
@@ -70,7 +70,7 @@ public class ControlLoop implements Observable.Transformer<Event, Double>  {
                 .doOnNext(sketch::update)
                 .lift(new ErrorComputer(config.setPoint, true, config.rope._1, config.rope._2))
                 .lift(new PIDController(config.kp, config.ki, config.kd, 1.0, new AtomicDouble(1.0), config.integralDecay))
-                .lift(new Integrator(currentScale.get(), config.minSize, config.maxSize))
+                .lift(new Integrator(currentScale.get(), config.minSize, config.maxSize, config.integralDecay))
                 .filter(__ -> this.cooldownMillis == 0 || cooldownTimestamp.get() <= System.currentTimeMillis() - this.cooldownMillis)
                 .filter(scale -> this.currentScale.get() != Math.round(Math.ceil(scale)))
                 .lift(actuator)

--- a/src/main/java/com/netflix/control/controllers/Integrator.java
+++ b/src/main/java/com/netflix/control/controllers/Integrator.java
@@ -23,6 +23,7 @@ public class Integrator extends IController {
     private double sum = 0;
     private double min = Double.NEGATIVE_INFINITY;
     private double max = Double.POSITIVE_INFINITY;
+    private double decayFactor = 1.0;
 
     public Integrator() {
     }
@@ -32,9 +33,14 @@ public class Integrator extends IController {
     }
 
     public Integrator(double init, double min, double max) {
+        this(init, min, max, 1.0);
+    }
+
+    public Integrator(double init, double min, double max, double decayFactor) {
         this.sum = init;
         this.min = min;
         this.max = max;
+        this.decayFactor = decayFactor;
     }
 
     /**
@@ -49,9 +55,10 @@ public class Integrator extends IController {
 
     @Override
     protected Double processStep(Double input) {
-        sum += input;
-        sum = (sum > max) ? max : sum;
-        sum = (sum < min) ? min : sum;
-        return sum;
+        double newSum = this.sum + input;
+        newSum = (newSum > max) ? max : newSum;
+        newSum = (newSum < min) ? min : newSum;
+        this.sum = decayFactor * newSum;
+        return newSum;
     }
 }

--- a/src/main/java/com/netflix/control/examples/ExampleAutoScaler.java
+++ b/src/main/java/com/netflix/control/examples/ExampleAutoScaler.java
@@ -75,7 +75,7 @@ public class ExampleAutoScaler implements Observable.Transformer<Double, Double>
                     instead we were required to produce only the differences (+2 for scale up two
                     workers, -3 to scale down three then we would omit the integrator.
                  */
-                .lift(new Integrator(1.0, min, max))
+                .lift(new Integrator(1.0, min, max, 1.0))
                 /*
                     We now feed this to an actuator which hows how to actually perform
                     the scaling action against the target. This can be achieved by performing a

--- a/src/test/java/com/netflix/control/controllers/IntegratorTest.java
+++ b/src/test/java/com/netflix/control/controllers/IntegratorTest.java
@@ -1,0 +1,34 @@
+package com.netflix.control.controllers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IntegratorTest {
+    @Test
+    public void shouldIntegrateInputs() {
+        Integrator integrator = new Integrator(10, -100, 100, 1.0);
+        double output = integrator.processStep(10.0);
+        assertEquals(20.0, output, 1e-10);
+
+        output = integrator.processStep(20.0);
+        assertEquals(40.0, output, 1e-10);
+
+        integrator.setSum(-10.0);
+        output = integrator.processStep(-10.0);
+        assertEquals(-20.0, output, 1e-10);
+    }
+
+    @Test
+    public void shouldSupportDecay() {
+        Integrator integrator = new Integrator(10, -100, 100, 0.9);
+        double output = integrator.processStep(10.0);
+        assertEquals(20.0, output, 1e-10);
+
+        output = integrator.processStep(20.0);
+        assertEquals(38.0, output, 1e-10);
+
+        output = integrator.processStep(30.0);
+        assertEquals(64.2, output, 1e-10);
+    }
+}

--- a/src/test/java/com/netflix/control/controllers/IntegratorTest.java
+++ b/src/test/java/com/netflix/control/controllers/IntegratorTest.java
@@ -31,4 +31,14 @@ public class IntegratorTest {
         output = integrator.processStep(30.0);
         assertEquals(64.2, output, 1e-10);
     }
+
+    @Test
+    public void shouldSupportMinMax() {
+        Integrator integrator = new Integrator(10, -100, 100, 1.0);
+        double output = integrator.processStep(200.0);
+        assertEquals(100.0, output, 1e-10);
+
+        output = integrator.processStep(-400.0);
+        assertEquals(-100.0, output, 1e-10);
+    }
 }


### PR DESCRIPTION
### Context

Add decay support to Integrator as well. Default decay to 1.0 so it behaves exactly the same as before.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
