### PR TITLE
Add hooks to customize clutch control loop, include sourcejob drop in rps metric

### DIFF
--- a/src/main/java/com/netflix/control/clutch/Clutch.java
+++ b/src/main/java/com/netflix/control/clutch/Clutch.java
@@ -54,7 +54,9 @@ public class Clutch implements Observable.Transformer<Event, Object> {
         /** A user defined resource metric provided by the job under control. Receives priority. */
         UserDefined,
         /** A measure of requests per second handled by the target. */
-        RPS
+        RPS,
+        /** Messages dropped by by the source job when sending to current job. */
+        SOURCEJOB_DROP
     }
 
     private final IActuator actuator;

--- a/src/main/java/com/netflix/control/clutch/ClutchConfiguration.java
+++ b/src/main/java/com/netflix/control/clutch/ClutchConfiguration.java
@@ -21,11 +21,13 @@ import java.util.concurrent.TimeUnit;
 import io.vavr.Tuple2;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 /**
  * Represents the overall configuration of a Clutch control loop.
  */
+@EqualsAndHashCode
 public @Builder(access = AccessLevel.PUBLIC) @Value class ClutchConfiguration {
 
     /** The Metric for which this configuration is intended. */

--- a/src/main/java/com/netflix/control/clutch/ClutchExperimental.java
+++ b/src/main/java/com/netflix/control/clutch/ClutchExperimental.java
@@ -118,10 +118,9 @@ public class ClutchExperimental implements Observable.Transformer<Event, Object>
         return events
                 .compose(new ExperimentalClutchConfigurator(new IClutchMetricsRegistry() { }, timer,
                         initialConfigMillis, configurator))
-                .flatMap(config -> events
+                .switchMap(config -> events
                         .compose(new ExperimentalControlLoop(config, this.actuator,
                                 this.initialSize.doubleValue(), new AtomicDouble(1.0), timer, size,
-                                this.rpsMetricComputer, this.scaleComputer))
-                        .takeUntil(timer)); // takeUntil tears down this control loop when a new config is produced.
+                                this.rpsMetricComputer, this.scaleComputer)));
     }
 }

--- a/src/main/java/com/netflix/control/clutch/ExperimentalClutchConfigurator.java
+++ b/src/main/java/com/netflix/control/clutch/ExperimentalClutchConfigurator.java
@@ -45,6 +45,7 @@ public class ExperimentalClutchConfigurator implements Observable.Transformer<Ev
         sketches.put(Clutch.Metric.DROPS, UpdateDoublesSketch.builder().setK(DEFAULT_K).build());
         sketches.put(Clutch.Metric.UserDefined, UpdateDoublesSketch.builder().setK(DEFAULT_K).build());
         sketches.put(Clutch.Metric.RPS, UpdateDoublesSketch.builder().setK(DEFAULT_K).build());
+        sketches.put(Clutch.Metric.SOURCEJOB_DROP, UpdateDoublesSketch.builder().setK(DEFAULT_K).build());
     }
 
     public ExperimentalClutchConfigurator(IClutchMetricsRegistry metricsRegistry, Observable<Long> timer,
@@ -91,6 +92,7 @@ public class ExperimentalClutchConfigurator implements Observable.Transformer<Ev
 
         return initialConfig
                 .concatWith(configs)
+                .distinctUntilChanged()
                 .doOnNext(__ -> log.info("RPS Sketch State: {}", sketches.get(Clutch.Metric.RPS)))
                 .doOnNext(__ -> logSketchSummary(sketches.get(Clutch.Metric.RPS)))
                 .doOnNext(config -> log.info("Clutch switched to config: {}", config));

--- a/src/main/java/com/netflix/control/clutch/ExperimentalClutchConfigurator.java
+++ b/src/main/java/com/netflix/control/clutch/ExperimentalClutchConfigurator.java
@@ -73,13 +73,13 @@ public class ExperimentalClutchConfigurator implements Observable.Transformer<Ev
     public Observable<ClutchConfiguration> call(Observable<Event> eventObservable) {
         Observable<ClutchConfiguration> configs = timer
                 .map(__ -> getConfig())
-                .doOnNext(config -> System.out.println("New Config: " + config.toString()));
+                .doOnNext(config -> log.info("New Config: ", config.toString()));
 
         Observable<ClutchConfiguration> initialConfig = Observable
                 .interval(this.initialConfigMilis, TimeUnit.MILLISECONDS)
                 .take(1)
                 .map(__ -> getConfig())
-                .doOnNext(config -> System.out.println("Initial Config: " + config.toString()));
+                .doOnNext(config -> log.info("Initial Config: {}", config.toString()));
 
         eventObservable
                 .filter(event -> event != null && event.metric != null)

--- a/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
+++ b/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
@@ -23,7 +23,6 @@ import com.netflix.control.IActuator;
 import com.netflix.control.controllers.ErrorComputer;
 import com.netflix.control.controllers.Integrator;
 import com.netflix.control.controllers.PIDController;
-import com.yahoo.sketches.quantiles.UpdateDoublesSketch;
 import io.vavr.Tuple;
 import lombok.extern.slf4j.Slf4j;
 import rx.Observable;
@@ -36,22 +35,26 @@ public class ExperimentalControlLoop implements Observable.Transformer<Event, Do
     private final IActuator actuator;
     private final Double initialSize;
     private final AtomicDouble dampener;
-    private final long cooldownMillis;
-
 
     private final AtomicLong cooldownTimestamp;
     private final AtomicLong currentScale;
     private final AtomicDouble lastLag;
     private final Observable<Long> timer;
     private final Observable<Integer> size;
+    private final IRpsMetricComputer rpsMetricComputer;
+    private final IScaleComputer scaleComputer;
+    private long cooldownMillis;
 
     public ExperimentalControlLoop(ClutchConfiguration config, IActuator actuator, Double initialSize,
                                    Observable<Long> timer, Observable<Integer> size) {
-        this(config, actuator, initialSize, new AtomicDouble(1.0), timer, size);
+        this(config, actuator, initialSize, new AtomicDouble(1.0), timer, size,
+                new DefaultRpsMetricComputer(), new DefaultScaleComputer());
     }
 
     public ExperimentalControlLoop(ClutchConfiguration config, IActuator actuator, Double initialSize,
-                                   AtomicDouble dampener, Observable<Long> timer, Observable<Integer> size) {
+                                   AtomicDouble dampener, Observable<Long> timer, Observable<Integer> size,
+                                   IRpsMetricComputer rpsMetricComputer,
+                                   IScaleComputer scaleComputer) {
         this.config = config;
         this.actuator = actuator;
         this.initialSize = initialSize;
@@ -63,6 +66,8 @@ public class ExperimentalControlLoop implements Observable.Transformer<Event, Do
         this.lastLag = new AtomicDouble(0.0);
         this.timer = timer;
         this.size = size;
+        this.rpsMetricComputer = rpsMetricComputer;
+        this.scaleComputer = scaleComputer;
     }
 
     @Override
@@ -79,32 +84,48 @@ public class ExperimentalControlLoop implements Observable.Transformer<Event, Do
 
         Observable<Event> rps = events.filter(event -> event.getMetric() == Clutch.Metric.RPS);
 
-        Integrator integrator = new Integrator(initialSize, config.minSize, config.maxSize, config.integralDecay);
+        Integrator deltaIntegrator = new Integrator(0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, config.integralDecay);
 
         size
                 .takeUntil(timer)
                 .doOnNext(currentScale::set)
-                .doOnNext(integrator::setSum)
                 .doOnNext(__ -> cooldownTimestamp.set(System.currentTimeMillis()))
                 .doOnNext(n -> log.info("Clutch received new scheduling update with {} workers.", n))
                 .subscribe();
 
         return rps.withLatestFrom(lag, drops, Tuple::of)
                 .doOnNext(triple -> log.debug("Clutch received RPS: {}, Lag: {} (d {}), Drops: {}", triple._1.value, triple._2.value, triple._2.value - lastLag.get(), triple._3.value))
-                .map(triple -> {
-                  double lagDerivative  = triple._2.value - lastLag.get();
-                  lastLag.set(triple._2.value);
-                    return triple._1.value // RPS
-                            + (lagDerivative) // Lag derivative is of Max lag, so already per-worker.
-                            + (triple._3.value); // Drops are average, and thus per-worker.
-                })
+                .map(triple -> this.rpsMetricComputer.apply(triple._1.value, triple._2.value, triple._3.value))
                 .lift(new ErrorComputer(config.setPoint, true, config.rope._1, config.rope._2))
                 .lift(new PIDController(config.kp, config.ki, config.kd, 1.0, new AtomicDouble(1.0), config.integralDecay))
-                .lift(integrator)
+                .lift(deltaIntegrator)
                 .filter(__ -> this.cooldownMillis == 0 || cooldownTimestamp.get() <= System.currentTimeMillis() - this.cooldownMillis)
+                .map(delta -> this.scaleComputer.apply(this.currentScale.get(), delta, (long) config.minSize, (long) config.maxSize))
                 .filter(scale -> this.currentScale.get() != Math.round(Math.ceil(scale)))
                 .lift(actuator)
                 .doOnNext(scale -> this.currentScale.set(Math.round(Math.ceil(scale))))
+                .doOnNext(__ -> deltaIntegrator.setSum(0))
                 .doOnNext(__ -> cooldownTimestamp.set(System.currentTimeMillis()));
+    }
+
+    /* For testing to trigger actuator on next event */
+    protected void setCooldownMillis(long cooldownMillis) {
+        this.cooldownMillis = cooldownMillis;
+    }
+
+    public static class DefaultRpsMetricComputer implements IRpsMetricComputer {
+        private double lastLag = 0;
+
+        public Double apply(Double rps, Double lag, Double drop) {
+            double lagDerivative  = lag - lastLag;
+            lastLag = lag;
+            return rps + lagDerivative + drop;
+        }
+    }
+
+    public static class DefaultScaleComputer implements IScaleComputer {
+        public Double apply(Long currentScale, Double delta, Long min, Long max) {
+            return Math.min(max, Math.max(min, currentScale + delta));
+        }
     }
 }

--- a/src/main/java/com/netflix/control/clutch/IRpsMetricComputer.java
+++ b/src/main/java/com/netflix/control/clutch/IRpsMetricComputer.java
@@ -16,17 +16,18 @@
 
 package com.netflix.control.clutch;
 
-import io.vavr.Function3;
+import io.vavr.Function2;
+
+import java.util.Map;
 
 /**
  * A function for computing the RPS metric to be compared against the setPoint and feed to the PID controller.
  * Arguments:
- * 1.) the latest RPS metric
- * 2.) the latest Lag metric
- * 3.) the latest Drop metric
+ * 1.) the clutch configuration for the current control loop
+ * 2.) a Map containing metrics for computation
  * Return:
  * the computed RPS metric
  */
 @FunctionalInterface
-public interface IRpsMetricComputer extends Function3<Double, Double, Double, Double> {
+public interface IRpsMetricComputer extends Function2<ClutchConfiguration, Map<Clutch.Metric, Double>, Double> {
 }

--- a/src/main/java/com/netflix/control/clutch/IRpsMetricComputer.java
+++ b/src/main/java/com/netflix/control/clutch/IRpsMetricComputer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.control.clutch;
+
+import io.vavr.Function3;
+
+/**
+ * A function for computing the RPS metric to be compared against the setPoint and feed to the PID controller.
+ * Arguments:
+ * 1.) the latest RPS metric
+ * 2.) the latest Lag metric
+ * 3.) the latest Drop metric
+ * Return:
+ * the computed RPS metric
+ */
+@FunctionalInterface
+public interface IRpsMetricComputer extends Function3<Double, Double, Double, Double> {
+}

--- a/src/main/java/com/netflix/control/clutch/IScaleComputer.java
+++ b/src/main/java/com/netflix/control/clutch/IScaleComputer.java
@@ -16,18 +16,17 @@
 
 package com.netflix.control.clutch;
 
-import io.vavr.Function4;
+import io.vavr.Function3;
 
 /**
  * A function for computing the new scale based on the current scale and the PID controller output.
  * Arguments:
- * 1.) the current scale
- * 2.) the delta computed by the PID controller
- * 3.) the scale min
- * 4.) the scale max
+ * 1.) the clutch configuration for the current control loop
+ * 2.) the current scale
+ * 3.) the delta computed by the PID controller
  * Return:
  * the new scale, which will be acted on by the actuator
  */
 @FunctionalInterface
-public interface IScaleComputer extends Function4<Long, Double, Long, Long, Double> {
+public interface IScaleComputer extends Function3<ClutchConfiguration, Long, Double, Double> {
 }

--- a/src/main/java/com/netflix/control/clutch/IScaleComputer.java
+++ b/src/main/java/com/netflix/control/clutch/IScaleComputer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.control.clutch;
+
+import io.vavr.Function4;
+
+/**
+ * A function for computing the new scale based on the current scale and the PID controller output.
+ * Arguments:
+ * 1.) the current scale
+ * 2.) the delta computed by the PID controller
+ * 3.) the scale min
+ * 4.) the scale max
+ * Return:
+ * the new scale, which will be acted on by the actuator
+ */
+@FunctionalInterface
+public interface IScaleComputer extends Function4<Long, Double, Long, Long, Double> {
+}

--- a/src/test/java/com/netflix/control/clutch/ExperimentalControlLoopTest.java
+++ b/src/test/java/com/netflix/control/clutch/ExperimentalControlLoopTest.java
@@ -1,0 +1,205 @@
+package com.netflix.control.clutch;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import com.netflix.control.IActuator;
+import io.vavr.Tuple;
+import org.junit.Test;
+import rx.Observable;
+import rx.subjects.PublishSubject;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExperimentalControlLoopTest {
+
+    @Test
+    public void shouldCallActuator() throws Exception {
+        ClutchConfiguration config = ClutchConfiguration.builder()
+                .metric(Clutch.Metric.RPS)
+                .setPoint(100.0)
+                .kp(1.0)
+                .ki(0)
+                .kd(0)
+                .minSize(1)
+                .maxSize(1000)
+                .rope(Tuple.of(0.0, 0.0))
+                .cooldownInterval(0)
+                .cooldownUnits(TimeUnit.SECONDS)
+                .build();
+        TestActuator actuator = new TestActuator();
+        CountDownLatch latch = actuator.createLatch();
+
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+                new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
+                new ExperimentalControlLoop.DefaultRpsMetricComputer(),
+                new ExperimentalControlLoop.DefaultScaleComputer());
+
+        PublishSubject<Event> publisher = PublishSubject.create();
+        controlLoop.call(publisher).subscribe();
+
+        publisher.onNext(new Event(Clutch.Metric.RPS, 110));
+        latch.await();
+        assertEquals(110, actuator.lastValue, 1e-10);
+
+        latch = actuator.createLatch();
+        publisher.onNext(new Event(Clutch.Metric.RPS, 120));
+        latch.await();
+        assertEquals(130, actuator.lastValue, 1e-10);
+
+        latch = actuator.createLatch();
+        publisher.onNext(new Event(Clutch.Metric.RPS, 90));
+        latch.await();
+        assertEquals(120, actuator.lastValue, 1e-10);
+
+        latch = actuator.createLatch();
+        publisher.onNext(new Event(Clutch.Metric.RPS, 0));
+        latch.await();
+        assertEquals(20, actuator.lastValue, 1e-10);
+
+        latch = actuator.createLatch();
+        publisher.onNext(new Event(Clutch.Metric.RPS, 0));
+        latch.await();
+        assertEquals(1, actuator.lastValue, 1e-10);
+
+        latch = actuator.createLatch();
+        publisher.onNext(new Event(Clutch.Metric.RPS, 2000));
+        latch.await();
+        assertEquals(1000, actuator.lastValue, 1e-10);
+    }
+
+    @Test
+    public void testLagDerivativeInMetricComputer() throws Exception {
+        ClutchConfiguration config = ClutchConfiguration.builder()
+                .metric(Clutch.Metric.RPS)
+                .setPoint(100.0)
+                .kp(1.0)
+                .ki(0)
+                .kd(0)
+                .minSize(1)
+                .maxSize(1000)
+                .rope(Tuple.of(0.0, 0.0))
+                .cooldownInterval(0)
+                .cooldownUnits(TimeUnit.SECONDS)
+                .build();
+        TestActuator actuator = new TestActuator();
+        CountDownLatch latch = actuator.createLatch();
+
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+                new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
+                new ExperimentalControlLoop.DefaultRpsMetricComputer(),
+                new ExperimentalControlLoop.DefaultScaleComputer());
+
+        PublishSubject<Event> publisher = PublishSubject.create();
+        controlLoop.call(publisher).subscribe();
+
+        publisher.onNext(new Event(Clutch.Metric.RPS, 110));
+        latch.await();
+        assertEquals(110, actuator.lastValue, 1e-10);
+
+        latch = actuator.createLatch();
+        publisher.onNext(new Event(Clutch.Metric.LAG, 20));
+        publisher.onNext(new Event(Clutch.Metric.RPS, 110));
+        latch.await();
+        assertEquals(140, actuator.lastValue, 1e-10);
+
+        latch = actuator.createLatch();
+        publisher.onNext(new Event(Clutch.Metric.LAG, 10));
+        publisher.onNext(new Event(Clutch.Metric.RPS, 100));
+        latch.await();
+        assertEquals(130, actuator.lastValue, 1e-10);
+    }
+
+    @Test
+    public void shouldIntegrateErrorDuringCoolDown() throws Exception {
+        ClutchConfiguration config = ClutchConfiguration.builder()
+                .metric(Clutch.Metric.RPS)
+                .setPoint(100.0)
+                .kp(1.0)
+                .ki(0)
+                .kd(0)
+                .minSize(1)
+                .maxSize(1000)
+                .rope(Tuple.of(0.0, 0.0))
+                .cooldownInterval(10)
+                .cooldownUnits(TimeUnit.MINUTES)
+                .build();
+        TestActuator actuator = new TestActuator();
+        CountDownLatch latch = actuator.createLatch();
+
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+                new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
+                new ExperimentalControlLoop.DefaultRpsMetricComputer(),
+                new ExperimentalControlLoop.DefaultScaleComputer());
+
+        PublishSubject<Event> publisher = PublishSubject.create();
+        controlLoop.call(publisher).subscribe();
+
+        publisher.onNext(new Event(Clutch.Metric.RPS, 110));
+        assertEquals(1, latch.getCount());
+
+        publisher.onNext(new Event(Clutch.Metric.RPS, 120));
+        assertEquals(1, latch.getCount());
+
+        controlLoop.setCooldownMillis(0);
+        publisher.onNext(new Event(Clutch.Metric.RPS, 90));
+        latch.await();
+        assertEquals(120, actuator.lastValue, 1e-10);
+    }
+
+    @Test
+    public void shouldIntegrateErrorWithDecay() throws Exception {
+        ClutchConfiguration config = ClutchConfiguration.builder()
+                .metric(Clutch.Metric.RPS)
+                .setPoint(100.0)
+                .kp(1.0)
+                .ki(0)
+                .kd(0)
+                .integralDecay(0.9)
+                .minSize(1)
+                .maxSize(1000)
+                .rope(Tuple.of(0.0, 0.0))
+                .cooldownInterval(10)
+                .cooldownUnits(TimeUnit.MINUTES)
+                .build();
+        TestActuator actuator = new TestActuator();
+        CountDownLatch latch = actuator.createLatch();
+
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+                new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
+                new ExperimentalControlLoop.DefaultRpsMetricComputer(),
+                new ExperimentalControlLoop.DefaultScaleComputer());
+
+        PublishSubject<Event> publisher = PublishSubject.create();
+        controlLoop.call(publisher).subscribe();
+
+        publisher.onNext(new Event(Clutch.Metric.RPS, 110));
+        assertEquals(1, latch.getCount());
+
+        publisher.onNext(new Event(Clutch.Metric.RPS, 120));
+        assertEquals(1, latch.getCount());
+
+        controlLoop.setCooldownMillis(0);
+        publisher.onNext(new Event(Clutch.Metric.RPS, 90));
+        latch.await();
+        assertEquals(116.1, actuator.lastValue, 1e-10);
+    }
+
+    public static class TestActuator extends IActuator {
+        private double lastValue;
+        private CountDownLatch latch;
+
+        public CountDownLatch createLatch() {
+            this.latch = new CountDownLatch(1);
+            return this.latch;
+        }
+
+        @Override
+        protected Double processStep(Double value) {
+            this.lastValue = value;
+            latch.countDown();
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
### Context

Add hooks to allow programmatically customize the Clutch control loop. The following hooks are added:
- IRpsMetricComputer
- IScaleComputer

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
