### PR TITLE
Add clutch metric enum for source job drop

### DIFF
--- a/src/main/java/com/netflix/control/clutch/Clutch.java
+++ b/src/main/java/com/netflix/control/clutch/Clutch.java
@@ -53,7 +53,9 @@ public class Clutch implements Observable.Transformer<Event, Object> {
         /** A user defined resource metric provided by the job under control. Receives priority. */
         UserDefined,
         /** A measure of requests per second handled by the target. */
-        RPS
+        RPS,
+        /** Messages dropped by by the source job when sending to current job. */
+        SOURCEJOB_DROP
     }
 
     private final IActuator actuator;


### PR DESCRIPTION
### Context

Add metric enum in preparation to use source job drop in clutch auto scale.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
