### PR TITLE
Fix bug where current number of worker is incorrect

### DIFF
--- a/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
+++ b/src/main/java/com/netflix/control/clutch/ExperimentalControlLoop.java
@@ -111,6 +111,7 @@ public class ExperimentalControlLoop implements Observable.Transformer<Event, Do
                 .doOnNext(d -> log.info("Integral: {}", d))
                 .filter(__ -> this.cooldownMillis == 0 || cooldownTimestamp.get() <= System.currentTimeMillis() - this.cooldownMillis)
                 .map(delta -> this.scaleComputer.apply(config, this.currentSize.get(), delta))
+                .doOnNext(d -> log.info("New desired size: {}, existing size: {}", d, this.currentSize.get()))
                 .filter(scale -> this.currentSize.get() != Math.round(Math.ceil(scale)))
                 .lift(actuator)
                 .doOnNext(scale -> this.currentSize.set(Math.round(Math.ceil(scale))))

--- a/src/test/java/com/netflix/control/clutch/ExperimentalControlLoopTest.java
+++ b/src/test/java/com/netflix/control/clutch/ExperimentalControlLoopTest.java
@@ -25,6 +25,7 @@ import rx.subjects.PublishSubject;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,7 +48,7 @@ public class ExperimentalControlLoopTest {
         TestActuator actuator = new TestActuator();
         CountDownLatch latch = actuator.createLatch();
 
-        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, new AtomicLong(100),
                 new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
                 new ExperimentalControlLoop.DefaultRpsMetricComputer(),
                 new ExperimentalControlLoop.DefaultScaleComputer());
@@ -102,7 +103,7 @@ public class ExperimentalControlLoopTest {
         TestActuator actuator = new TestActuator();
         CountDownLatch latch = actuator.createLatch();
 
-        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, new AtomicLong(100),
                 new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
                 new ExperimentalControlLoop.DefaultRpsMetricComputer(),
                 new ExperimentalControlLoop.DefaultScaleComputer());
@@ -144,7 +145,7 @@ public class ExperimentalControlLoopTest {
         TestActuator actuator = new TestActuator();
         CountDownLatch latch = actuator.createLatch();
 
-        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, new AtomicLong(100),
                 new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
                 new ExperimentalControlLoop.DefaultRpsMetricComputer(),
                 new ExperimentalControlLoop.DefaultScaleComputer());
@@ -182,7 +183,7 @@ public class ExperimentalControlLoopTest {
         TestActuator actuator = new TestActuator();
         CountDownLatch latch = actuator.createLatch();
 
-        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, 100.0,
+        ExperimentalControlLoop controlLoop = new ExperimentalControlLoop(config, actuator, new AtomicLong(100),
                 new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
                 new ExperimentalControlLoop.DefaultRpsMetricComputer(),
                 new ExperimentalControlLoop.DefaultScaleComputer());


### PR DESCRIPTION
### Context

Use an AtomicLong to hold the current number of workers. The AtomicLong is updated from an Observable. This ensures the current worker count is up to date.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
